### PR TITLE
[security fix] mitigate rce in documentation playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 wip.md
 todo.md
 .ddev/config.yaml
+docs/src/.enable-playground

--- a/docs/src/tester.php
+++ b/docs/src/tester.php
@@ -66,9 +66,28 @@ function dump($obj) {
  */
 if (isset($_POST['markdown'])) {
     header('Content-Type: application/json');
+
+    // Security Gate: PHP Execution is disabled by default.
+    $php = $_POST['php'] ?? '';
+    if ($php) {
+        $isLocal = in_array($_SERVER['REMOTE_ADDR'] ?? '', ['127.0.0.1', '::1']);
+        $isDevEnv = getenv('DDEV_PROJECT') || getenv('IS_DDEV');
+        $isEnabled = file_exists(__DIR__ . '/.enable-playground');
+
+        if (!$isEnabled || (!$isLocal && !$isDevEnv)) {
+            http_response_code(403);
+            echo json_encode([
+                'error' => "Security Gate: PHP Execution is disabled. To enable it for local development:\n" .
+                           "1. Ensure you are on localhost or DDEV.\n" .
+                           "2. Create an empty file at docs/src/.enable-playground\n\n" .
+                           "This prevents accidental RCE on production servers."
+            ]);
+            exit;
+        }
+    }
+
     try {
         $md = $_POST['markdown'];
-        $php = $_POST['php'] ?? '';
         
         $constructor = (new \ReflectionClass(LetMeDown::class))->getConstructor();
         $parser = $constructor && $constructor->getNumberOfParameters() >= 2
@@ -334,7 +353,7 @@ function explorer($obj, $name = 'root', $depth = 0) {
             const data = await resp.json();
             
             if (data.error) {
-                document.getElementById('preview-area').innerHTML = `<div style="color:red; font-family:monospace;">${data.error}</div>`;
+                document.getElementById('preview-area').innerHTML = `<div style="color:red; font-family:monospace; white-space:pre-wrap; padding:10px;">${data.error}</div>`;
                 return;
             }
 


### PR DESCRIPTION
What: Remote Code Execution (RCE) vulnerability in the documentation playground.
Risk: The eval() function was directly using $_POST input, allowing arbitrary code execution if the file is accessible on a public server.
Solution: Implemented a security gate that requires the request to come from a local environment (localhost or DDEV) and the existence of a .enable-playground file (which is git-ignored) before allowing PHP execution. Added frontend feedback to guide developers on how to enable the tool for local use.

---
*PR created automatically by Jules for task [16846673667573467557](https://jules.google.com/task/16846673667573467557) started by @lemachinarbo*